### PR TITLE
Fix release push: disable persist-credentials when app token is used

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,9 @@ runs:
 
     - name: Checkout
       if: inputs.checkout == 'true'
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: ${{ inputs.release-app-id == '' }}
 
     - name: Detect Release
       id: release-detect


### PR DESCRIPTION
## Summary

- Upgrade checkout from `actions/checkout@v5` to `@v6`
- Set `persist-credentials` to `false` when `release-app-id` is provided, preventing the default `GITHUB_TOKEN` credential helper from overriding the app token during `git push`
- When no app is configured, credentials persist as before (no behavior change)

Fixes release pushes failing with `GH013: Repository rule violations` on repos with branch protection rulesets.

## Test plan

- [ ] Release push succeeds on a repo with branch protection and PyBuilder app configured
- [ ] Non-release builds without app credentials are unaffected